### PR TITLE
CCM-8574: add support for sqs delay queues

### DIFF
--- a/infrastructure/modules/sqs/README.md
+++ b/infrastructure/modules/sqs/README.md
@@ -17,6 +17,7 @@
 | <a name="input_content_based_deduplication"></a> [content\_based\_deduplication](#input\_content\_based\_deduplication) | Enables content-based deduplication for FIFO queues | `bool` | `false` | no |
 | <a name="input_create_dlq"></a> [create\_dlq](#input\_create\_dlq) | Create a DLQ | `bool` | `false` | no |
 | <a name="input_default_tags"></a> [default\_tags](#input\_default\_tags) | A map of default tags to apply to all taggable resources within the component | `map(string)` | `{}` | no |
+| <a name="input_delay_seconds"></a> [delay\_seconds](#input\_delay\_seconds) | Time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes). | `number` | `0` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the tfscaffold environment | `string` | n/a | yes |
 | <a name="input_fifo_queue"></a> [fifo\_queue](#input\_fifo\_queue) | Boolean designating a FIFO queue | `bool` | `false` | no |
 | <a name="input_kms_data_key_reuse_period_seconds"></a> [kms\_data\_key\_reuse\_period\_seconds](#input\_kms\_data\_key\_reuse\_period\_seconds) | The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours) | `number` | `300` | no |

--- a/infrastructure/modules/sqs/sqs_queue.tf
+++ b/infrastructure/modules/sqs/sqs_queue.tf
@@ -3,6 +3,7 @@ resource "aws_sqs_queue" "sqs_queue" {
 
   message_retention_seconds   = var.message_retention_seconds
   visibility_timeout_seconds  = var.visibility_timeout_seconds
+  delay_seconds               = var.delay_seconds
   fifo_queue                  = var.fifo_queue
   content_based_deduplication = var.content_based_deduplication
   max_message_size            = var.max_message_size

--- a/infrastructure/modules/sqs/variables.tf
+++ b/infrastructure/modules/sqs/variables.tf
@@ -81,6 +81,12 @@ variable "visibility_timeout_seconds" {
   default     = 300
 }
 
+variable "delay_seconds" {
+  description = "Time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes)."
+  type        = number
+  default     = 0
+}
+
 variable "fifo_queue" {
   description = "Boolean designating a FIFO queue"
   type        = bool


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds support for setting `delay_seconds` attribute on SQS Queue module. 

## Context

I need an SQS queue with `delay_seconds` set.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-delay-queues.html
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sqs_queue#delay_seconds-1

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
