### PR TITLE
CCM-10464: add configurable lambda resource policies

### DIFF
--- a/infrastructure/modules/lambda/README.md
+++ b/infrastructure/modules/lambda/README.md
@@ -41,6 +41,7 @@
 | <a name="input_log_subscription_lambda_create_permission"></a> [log\_subscription\_lambda\_create\_permission](#input\_log\_subscription\_lambda\_create\_permission) | Whether to create a permission for the log forwarder. Set to false if using a generic one. | `bool` | `true` | no |
 | <a name="input_log_subscription_role_arn"></a> [log\_subscription\_role\_arn](#input\_log\_subscription\_role\_arn) | The ARN of the IAM role to use for the log subscription filter | `string` | `""` | no |
 | <a name="input_memory"></a> [memory](#input\_memory) | The amount of memory to apply to the created Lambda | `number` | n/a | yes |
+| <a name="input_permission_statements"></a> [permission\_statements](#input\_permission\_statements) | Statements giving an external source permission to invoke the Lambda function | <pre>list(object({<br/>    action         = optional(string)<br/>    principal      = string<br/>    source_arn     = optional(string)<br/>    source_account = optional(string)<br/>    statement_id   = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_project"></a> [project](#input\_project) | The name of the tfscaffold project | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The AWS Region | `string` | n/a | yes |
 | <a name="input_runtime"></a> [runtime](#input\_runtime) | The runtime to use for the lambda function | `string` | n/a | yes |

--- a/infrastructure/modules/lambda/lambda_permissions.tf
+++ b/infrastructure/modules/lambda/lambda_permissions.tf
@@ -1,0 +1,10 @@
+resource "aws_lambda_permission" "main" {
+  for_each = { for statement in var.permission_statements : statement.statement_id => statement }
+
+  action         = try(each.value.action, "lambda:InvokeFunction")
+  function_name  = local.csi
+  principal      = each.value.principal
+  source_arn     = try(each.value.source_arn, null)
+  source_account = try(each.value.source_account, null)
+  statement_id   = each.value.statement_id
+}

--- a/infrastructure/modules/lambda/variables.tf
+++ b/infrastructure/modules/lambda/variables.tf
@@ -236,3 +236,15 @@ variable "log_subscription_role_arn" {
   description = "The ARN of the IAM role to use for the log subscription filter"
   default     = ""
 }
+
+variable "permission_statements" {
+  type = list(object({
+    action         = optional(string)
+    principal      = string
+    source_arn     = optional(string)
+    source_account = optional(string)
+    statement_id   = string
+  }))
+  description = "Statements giving an external source permission to invoke the Lambda function"
+  default     = []
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Adds input variable to lambda module allowing the consumer to configure resource policies on the lambda function, allowing external services to invoke the function.

## Context

I have a Lambda that is to be invoked by Cognito - I need to give Cognito permission to invoke the Lambda.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
