### PR TITLE
CCM-11888: Append ca to subject common name

### DIFF
--- a/infrastructure/modules/ssl/tls_self_signed_cert_ca_cert.tf
+++ b/infrastructure/modules/ssl/tls_self_signed_cert_ca_cert.tf
@@ -7,7 +7,7 @@ resource "tls_self_signed_cert" "ca_cert" {
     country             = var.subject_country
     province            = var.subject_province
     locality            = var.subject_locality
-    common_name         = var.subject_common_name
+    common_name         = "ca-${var.subject_common_name}"
     organization        = var.subject_organization
     organizational_unit = var.subject_organizational_unit
   }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Appends `ca-` to the subject common name for the self signed CA cert.

## Context

Stops openssl claiming the server.crt is self signed.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
