### PR TITLE
CCM-12224: inline standard lambda policies to reduce policy resource usage

### DIFF
--- a/infrastructure/modules/lambda/iam_policy_publish.tf
+++ b/infrastructure/modules/lambda/iam_policy_publish.tf
@@ -1,7 +1,0 @@
-resource "aws_iam_policy" "publish" {
-  count = var.enable_dlq_and_notifications ? 1 : 0
-
-  name        = "${local.csi}-publish"
-  description = "SNS Publish policy for ${var.function_name} Lambda"
-  policy      = data.aws_iam_policy_document.publish[0].json
-}

--- a/infrastructure/modules/lambda/iam_policy_put_logs.tf
+++ b/infrastructure/modules/lambda/iam_policy_put_logs.tf
@@ -1,5 +1,0 @@
-resource "aws_iam_policy" "put_logs" {
-  name        = "${local.csi}-put-logs"
-  description = "Logging policy for ${var.function_name} Lambda"
-  policy      = data.aws_iam_policy_document.put_logs.json
-}

--- a/infrastructure/modules/lambda/iam_policy_send_message.tf
+++ b/infrastructure/modules/lambda/iam_policy_send_message.tf
@@ -1,7 +1,0 @@
-resource "aws_iam_policy" "send_message" {
-  count = var.enable_dlq_and_notifications ? 1 : 0
-
-  name        = "${local.csi}-send-message"
-  description = "SQS DLQ SendMessage policy for ${var.function_name} Lambda"
-  policy      = data.aws_iam_policy_document.send_message[0].json
-}

--- a/infrastructure/modules/lambda/iam_role_policy_attachment_publish.tf
+++ b/infrastructure/modules/lambda/iam_role_policy_attachment_publish.tf
@@ -1,6 +1,0 @@
-resource "aws_iam_role_policy_attachment" "publish" {
-  count = var.enable_dlq_and_notifications ? 1 : 0
-
-  role       = aws_iam_role.main.name
-  policy_arn = aws_iam_policy.publish[0].arn
-}

--- a/infrastructure/modules/lambda/iam_role_policy_attachment_put_logs.tf
+++ b/infrastructure/modules/lambda/iam_role_policy_attachment_put_logs.tf
@@ -1,4 +1,0 @@
-resource "aws_iam_role_policy_attachment" "put_logs" {
-  role       = aws_iam_role.main.name
-  policy_arn = aws_iam_policy.put_logs.arn
-}

--- a/infrastructure/modules/lambda/iam_role_policy_attachment_send_message.tf
+++ b/infrastructure/modules/lambda/iam_role_policy_attachment_send_message.tf
@@ -1,6 +1,0 @@
-resource "aws_iam_role_policy_attachment" "send_message" {
-  count = var.enable_dlq_and_notifications ? 1 : 0
-
-  role       = aws_iam_role.main.name
-  policy_arn = aws_iam_policy.send_message[0].arn
-}

--- a/infrastructure/modules/lambda/iam_role_policy_publish.tf
+++ b/infrastructure/modules/lambda/iam_role_policy_publish.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_role_policy" "publish" {
+  count = var.enable_dlq_and_notifications ? 1 : 0
+
+  name   = "${local.csi}-publish"
+  role   = aws_iam_role.main.id
+  policy = data.aws_iam_policy_document.publish[0].json
+}

--- a/infrastructure/modules/lambda/iam_role_policy_put_logs.tf
+++ b/infrastructure/modules/lambda/iam_role_policy_put_logs.tf
@@ -1,0 +1,5 @@
+resource "aws_iam_role_policy" "put_logs" {
+  name   = "${local.csi}-put-logs"
+  role   = aws_iam_role.main.id
+  policy = data.aws_iam_policy_document.put_logs.json
+}

--- a/infrastructure/modules/lambda/iam_role_policy_send_message.tf
+++ b/infrastructure/modules/lambda/iam_role_policy_send_message.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_role_policy" "send_message" {
+  count = var.enable_dlq_and_notifications ? 1 : 0
+
+  name   = "${local.csi}-send-message"
+  role   = aws_iam_role.main.id
+  policy = data.aws_iam_policy_document.send_message[0].json
+}


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Replaces managed IAM policy resources with inline policies in Lambda module.

## Context

We're hitting IAM Policy resource limits in template-management dev. Looking at some sandbox environments, it looks like each sandbox env has 

- 21 lambda functions
- 50 IAM policies

The lambda-related IAM policies in each environment include:
- 18 "main" policies (permissions specific to that lambda)
- 20 "logging" policies (allowing the lambda to write logs)
- 4 "publish" policies (allowing the lambda to publish to SNS when `enable_dlq_and_notifications` is true)
- 4 "send_message" policies (allowing the lambda to send to SQS DLQ when `enable_dlq_and_notifications` is true)

This replaces the "logging", "publish" and "send_message" policy resources and adds them as inline policies on the lambda role.

You can have an unlimited number of inline policies up to a total of 10240 characters attached to a role. Here I'm attaching 3 policies, and the total characters will be well under the character limit.

I've left the "main" policy as a managed policy resource as it gives you a 6144 character limit which is separate from the inline limit. 

But as an example, this change should reduce the number of IAM policies per templates sandbox environment from 50 to 22. 

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
