### PR TITLE
CCM-16484: Improve lambda_env_vars output

### DIFF
--- a/infrastructure/terraform/modules/lambda/outputs.tf
+++ b/infrastructure/terraform/modules/lambda/outputs.tf
@@ -20,7 +20,7 @@ output "function_qualified_arn" {
 
 output "function_env_vars" {
   description = "Environment variables for the Lambda function"
-  value       = length(var.lambda_env_vars) == 0 ? {} : aws_lambda_function.main.environment[0].variables
+  value       = var.lambda_env_vars
 }
 
 output "iam_role_name" {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Simplify the `lambda_env_vars` output to make it less defensive.

## Context

Though it looks more safe and defensive, where the module calls insert something into the variable that cannot be resolved at plan time (Skynet hit this with s3bucket.this.id) it can cause the plan to fail. 

Deployed to sbx env in template management, using this branch to modify the source of 33 lambdas in the backend-api module:

https://github.com/NHSDigital/nhs-notify-shared-modules/pull/173
https://github.com/NHSDigital/nhs-notify-internal/actions/runs/24185496908

Deploys successfully and all tests pass/
## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
