### PR TITLE
CCM-17036: Fix Pre Commit Hook Args

### DIFF
--- a/.github/actions/check-english-usage/check-english-usage.sh
+++ b/.github/actions/check-english-usage/check-english-usage.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 function main() {
 
   cd "$(git rev-parse --show-toplevel)"
+  apply-key-value-args "$@"
 
   check=${check:-working-tree-changes}
   case $check in
@@ -113,6 +114,19 @@ function is-arg-true() {
   else
     return 1
   fi
+}
+
+# Parse arguments passed by pre-commit as KEY=VALUE and expose them as env vars.
+function apply-key-value-args() {
+
+  for arg in "$@"; do
+    if [[ "$arg" =~ ^[A-Za-z_][A-Za-z0-9_]*=.+$ ]]; then
+      export "$arg"
+    else
+      echo "Unknown argument format: $arg (expected key=value)" >&2
+      exit 126
+    fi
+  done
 }
 
 # ==============================================================================

--- a/.github/actions/check-file-format/check-file-format.sh
+++ b/.github/actions/check-file-format/check-file-format.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 #
 # Options:
 #   check={all,staged-changes,working-tree-changes,branch}  # Check mode, default is 'working-tree-changes'
+#   exclude=file1,file2                                     # Comma-separated file paths to skip
 #   dry_run=true                                            # Do not check, run dry run only, default is 'false'
 #   BRANCH_NAME=other-branch-than-main                      # Branch to compare with, default is `origin/main`
 #   FORCE_USE_DOCKER=true                                   # If set to true the command is run in a Docker container, default is 'false'
@@ -43,6 +44,7 @@ set -euo pipefail
 function main() {
 
   cd "$(git rev-parse --show-toplevel)"
+  apply-key-value-args "$@"
 
   # shellcheck disable=SC2154
   is-arg-true "${dry_run:-false}" && dry_run_opt="--dry-run"
@@ -82,7 +84,7 @@ function run-editorconfig-natively() {
   local files=()
   while IFS= read -r -d '' file; do
     files+=("$file")
-  done < <($filter)
+  done < <(get-filtered-files)
 
   # If no files found, exit successfully
   [[ ${#files[@]} -eq 0 ]] && return 0
@@ -107,7 +109,7 @@ function run-editorconfig-in-docker() {
   local files=()
   while IFS= read -r -d '' file; do
     files+=("$file")
-  done < <($filter)
+  done < <(get-filtered-files)
 
   # We use /dev/null here as a backstop in case there are no files in the state
   # we choose. If the filter comes back empty, adding `/dev/null` onto it has
@@ -123,6 +125,31 @@ function run-editorconfig-in-docker() {
       ec --exclude '.git/' $dry_run_opt "${files[@]}"
 }
 
+# Run the selected filter and remove files listed in the optional `exclude` argument.
+function get-filtered-files() {
+
+  local excludes_csv="${exclude:-}"
+
+  if [[ -z "$excludes_csv" ]]; then
+    $filter
+    return 0
+  fi
+
+  local excludes=()
+  IFS=',' read -r -a excludes <<< "$excludes_csv"
+
+  while IFS= read -r -d '' file; do
+    local skip=false
+    for ex in "${excludes[@]}"; do
+      ex="${ex#${ex%%[![:space:]]*}}"
+      ex="${ex%${ex##*[![:space:]]}}"
+      [[ "$file" == "$ex" ]] && skip=true && break
+    done
+
+    [[ "$skip" == false ]] && printf '%s\0' "$file"
+  done < <($filter)
+}
+
 # ==============================================================================
 
 function is-arg-true() {
@@ -132,6 +159,19 @@ function is-arg-true() {
   else
     return 1
   fi
+}
+
+# Parse arguments passed by pre-commit as KEY=VALUE and expose them as env vars.
+function apply-key-value-args() {
+
+  for arg in "$@"; do
+    if [[ "$arg" =~ ^[A-Za-z_][A-Za-z0-9_]*=.+$ ]]; then
+      export "$arg"
+    else
+      echo "Unknown argument format: $arg (expected key=value)" >&2
+      exit 126
+    fi
+  done
 }
 
 # ==============================================================================

--- a/.github/actions/check-markdown-format/check-markdown-format.sh
+++ b/.github/actions/check-markdown-format/check-markdown-format.sh
@@ -34,6 +34,7 @@ set -euo pipefail
 function main() {
 
   cd "$(git rev-parse --show-toplevel)"
+  apply-key-value-args "$@"
 
   check=${check:-working-tree-changes}
   case $check in
@@ -98,6 +99,19 @@ function is-arg-true() {
   else
     return 1
   fi
+}
+
+# Parse arguments passed by pre-commit as KEY=VALUE and expose them as env vars.
+function apply-key-value-args() {
+
+  for arg in "$@"; do
+    if [[ "$arg" =~ ^[A-Za-z_][A-Za-z0-9_]*=.+$ ]]; then
+      export "$arg"
+    else
+      echo "Unknown argument format: $arg (expected key=value)" >&2
+      exit 126
+    fi
+  done
 }
 
 # ==============================================================================

--- a/.github/actions/check-todo-usage/check-todos.sh
+++ b/.github/actions/check-todo-usage/check-todos.sh
@@ -214,6 +214,7 @@ function print_output() {
 
 function main() {
   cd "$(git rev-parse --show-toplevel)"
+  apply-key-value-args "$@"
 
   # Load exclusions from config file
   load_exclusions_from_config "$CONFIG_FILE"
@@ -242,6 +243,19 @@ function is-arg-true() {
   else
     return 1
   fi
+}
+
+# Parse arguments passed by pre-commit as KEY=VALUE and expose them as env vars.
+function apply-key-value-args() {
+
+  for arg in "$@"; do
+    if [[ "$arg" =~ ^[A-Za-z_][A-Za-z0-9_]*=.+$ ]]; then
+      export "$arg"
+    else
+      echo "Unknown argument format: $arg (expected key=value)" >&2
+      exit 126
+    fi
+  done
 }
 
 # ==============================================================================

--- a/.github/actions/scan-secrets/scan-secrets.sh
+++ b/.github/actions/scan-secrets/scan-secrets.sh
@@ -26,6 +26,7 @@ set -euo pipefail
 function main() {
 
   cd "$(git rev-parse --show-toplevel)"
+  apply-key-value-args "$@"
 
   if command -v gitleaks > /dev/null 2>&1 && ! is-arg-true "${FORCE_USE_DOCKER:-false}"; then
     dir="$PWD"
@@ -100,6 +101,19 @@ function is-arg-true() {
   else
     return 1
   fi
+}
+
+# Parse arguments passed by pre-commit as KEY=VALUE and expose them as env vars.
+function apply-key-value-args() {
+
+  for arg in "$@"; do
+    if [[ "$arg" =~ ^[A-Za-z_][A-Za-z0-9_]*=.+$ ]]; then
+      export "$arg"
+    else
+      echo "Unknown argument format: $arg (expected key=value)" >&2
+      exit 126
+    fi
+  done
 }
 
 # ==============================================================================


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Shared githook scripts now parse and convert positional args to env vars. Remote repos sourcing and running the pre-commits use 'arg:' in the pre-commit.yaml which resolve as positional args.


## Context

Currently shared githooks are being run without the provided args so with default values.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
