### PR TITLE
CCM-18398: Allow access to eventpub's event cache bucket to be restricted

### DIFF
--- a/infrastructure/terraform/modules/eventpub/README.md
+++ b/infrastructure/terraform/modules/eventpub/README.md
@@ -30,6 +30,7 @@
 | <a name="input_event_anomaly_period"></a> [event\_anomaly\_period](#input\_event\_anomaly\_period) | The period in seconds over which the specified statistic is applied for anomaly detection. Minimum 300 seconds (5 minutes). Recommended: 300-600. | `number` | `300` | no |
 | <a name="input_event_cache_buffer_interval"></a> [event\_cache\_buffer\_interval](#input\_event\_cache\_buffer\_interval) | The buffer interval for data firehose | `number` | `500` | no |
 | <a name="input_event_cache_expiry_days"></a> [event\_cache\_expiry\_days](#input\_event\_cache\_expiry\_days) | s3 archiving expiry in days | `number` | `30` | no |
+| <a name="input_event_cache_restrict_data_access"></a> [event\_cache\_restrict\_data\_access](#input\_event\_cache\_restrict\_data\_access) | Whether to restrict access to PII data in the event cache bucket | `bool` | `false` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | When enabled will force destroy event-cache S3 bucket | `bool` | `false` | no |
 | <a name="input_group"></a> [group](#input\_group) | The name of the tfscaffold group | `string` | `null` | no |
 | <a name="input_iam_permissions_boundary_arn"></a> [iam\_permissions\_boundary\_arn](#input\_iam\_permissions\_boundary\_arn) | The ARN of the permissions boundary to use for the IAM role | `string` | `null` | no |

--- a/infrastructure/terraform/modules/eventpub/README.md
+++ b/infrastructure/terraform/modules/eventpub/README.md
@@ -30,7 +30,7 @@
 | <a name="input_event_anomaly_period"></a> [event\_anomaly\_period](#input\_event\_anomaly\_period) | The period in seconds over which the specified statistic is applied for anomaly detection. Minimum 300 seconds (5 minutes). Recommended: 300-600. | `number` | `300` | no |
 | <a name="input_event_cache_buffer_interval"></a> [event\_cache\_buffer\_interval](#input\_event\_cache\_buffer\_interval) | The buffer interval for data firehose | `number` | `500` | no |
 | <a name="input_event_cache_expiry_days"></a> [event\_cache\_expiry\_days](#input\_event\_cache\_expiry\_days) | s3 archiving expiry in days | `number` | `30` | no |
-| <a name="input_event_cache_restrict_data_access"></a> [event\_cache\_restrict\_data\_access](#input\_event\_cache\_restrict\_data\_access) | Whether to restrict access to PII data in the event cache bucket | `bool` | `false` | no |
+| <a name="input_event_cache_restrict_data_access"></a> [event\_cache\_restrict\_data\_access](#input\_event\_cache\_restrict\_data\_access) | Whether to restrict access to data in the event cache bucket | `bool` | `false` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | When enabled will force destroy event-cache S3 bucket | `bool` | `false` | no |
 | <a name="input_group"></a> [group](#input\_group) | The name of the tfscaffold group | `string` | `null` | no |
 | <a name="input_iam_permissions_boundary_arn"></a> [iam\_permissions\_boundary\_arn](#input\_iam\_permissions\_boundary\_arn) | The ARN of the permissions boundary to use for the IAM role | `string` | `null` | no |

--- a/infrastructure/terraform/modules/eventpub/module_s3bucket_event_cache.tf
+++ b/infrastructure/terraform/modules/eventpub/module_s3bucket_event_cache.tf
@@ -1,5 +1,5 @@
 module "s3bucket_event_cache" {
-  source = "https://github.com/NHSDigital/nhs-notify-shared-modules/releases/download/3.0.3/terraform-s3bucket.zip"
+  source = "https://github.com/NHSDigital/nhs-notify-shared-modules/releases/download/4.0.5/terraform-s3bucket.zip"
 
   count = var.enable_event_cache ? 1 : 0
 
@@ -14,6 +14,7 @@ module "s3bucket_event_cache" {
   acl           = "private"
   force_destroy = var.force_destroy
   versioning    = true
+  enable_abac   = var.event_cache_restrict_data_access
 
   lifecycle_rules = [
     {
@@ -54,7 +55,8 @@ module "s3bucket_event_cache" {
   }
 
   default_tags = {
-    Name = "Event Cache Storage"
+    Name                = "Event Cache Storage"
+    NHSE-RESTRICTED-PID = "True"
   }
 }
 

--- a/infrastructure/terraform/modules/eventpub/module_s3bucket_event_cache.tf
+++ b/infrastructure/terraform/modules/eventpub/module_s3bucket_event_cache.tf
@@ -56,7 +56,7 @@ module "s3bucket_event_cache" {
 
   default_tags = {
     Name                = "Event Cache Storage"
-    NHSE-RESTRICTED-PID = "True"
+    NHSE-RESTRICTED-PID = var.event_cache_restrict_data_access ? "True" : "False"
   }
 }
 

--- a/infrastructure/terraform/modules/eventpub/variables.tf
+++ b/infrastructure/terraform/modules/eventpub/variables.tf
@@ -97,6 +97,12 @@ variable "enable_event_cache" {
   default     = false
 }
 
+variable "event_cache_restrict_data_access" {
+  type        = bool
+  description = "Whether to restrict access to PII data in the event cache bucket"
+  default     = false
+}
+
 variable "enable_firehose_raw_message_delivery" {
   type        = bool
   description = "Enables raw message delivery on firehose subscription"

--- a/infrastructure/terraform/modules/eventpub/variables.tf
+++ b/infrastructure/terraform/modules/eventpub/variables.tf
@@ -99,7 +99,7 @@ variable "enable_event_cache" {
 
 variable "event_cache_restrict_data_access" {
   type        = bool
-  description = "Whether to restrict access to PII data in the event cache bucket"
+  description = "Whether to restrict access to data in the event cache bucket"
   default     = false
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR adds an `event_cache_restrict_data_access` boolean flag to the `eventpub` module's variables and uses it to set the `enable_abac` property and `NHSE-RESTRICTED-PID` tag on the module's event cache S3 bucket.

The updated module will be used (and has been tested) in [this Digital Letters PR](https://github.com/NHSDigital/nhs-notify-digital-letters/pull/381).

## Context

This change is required because the Digital Letters domain contains PII (an NHS number) in some of its event payloads. This means that Digital Letters needs to be able to restrict access to the event cache S3 bucket in production accounts.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
