### PR TITLE
CCM-15190: pre-commit -- ignore git submodules

### DIFF
--- a/.github/actions/check-english-usage/check-english-usage.sh
+++ b/.github/actions/check-english-usage/check-english-usage.sh
@@ -35,13 +35,13 @@ function main() {
       filter="git ls-files -z"
       ;;
     "staged-changes")
-      filter="git diff --diff-filter=ACMRT --name-only --cached -z"
+      filter="git diff --diff-filter=ACMRT --name-only --cached --ignore-submodules=all -z"
       ;;
     "working-tree-changes")
-      filter="git diff --diff-filter=ACMRT --name-only -z"
+      filter="git diff --diff-filter=ACMRT --name-only --ignore-submodules=all -z"
       ;;
     "branch")
-      filter="git diff --diff-filter=ACMRT --name-only -z ${BRANCH_NAME:-origin/main}"
+      filter="git diff --diff-filter=ACMRT --name-only --ignore-submodules=all -z ${BRANCH_NAME:-origin/main}"
       ;;
     *)
       echo "Unrecognised check mode: $check" >&2 && exit 1

--- a/.github/actions/check-file-format/check-file-format.sh
+++ b/.github/actions/check-file-format/check-file-format.sh
@@ -55,13 +55,13 @@ function main() {
       filter="git ls-files -z"
       ;;
     "staged-changes")
-      filter="git diff --diff-filter=ACMRT --name-only --cached -z"
+      filter="git diff --diff-filter=ACMRT --name-only --cached --ignore-submodules=all -z"
       ;;
     "working-tree-changes")
-      filter="git diff --diff-filter=ACMRT --name-only -z"
+      filter="git diff --diff-filter=ACMRT --name-only --ignore-submodules=all -z"
       ;;
     "branch")
-      filter="git diff --diff-filter=ACMRT --name-only -z ${BRANCH_NAME:-origin/main}"
+      filter="git diff --diff-filter=ACMRT --name-only --ignore-submodules=all -z ${BRANCH_NAME:-origin/main}"
       ;;
     *)
       echo "Unrecognised check mode: $check" >&2 && exit 1

--- a/.github/actions/check-markdown-format/check-markdown-format.sh
+++ b/.github/actions/check-markdown-format/check-markdown-format.sh
@@ -42,13 +42,13 @@ function main() {
       files="$(git ls-files "*.md")"
       ;;
     "staged-changes")
-      files="$(git diff --diff-filter=ACMRT --name-only --cached "*.md")"
+      files="$(git diff --diff-filter=ACMRT --name-only --cached --ignore-submodules=all "*.md")"
       ;;
     "working-tree-changes")
-      files="$(git diff --diff-filter=ACMRT --name-only "*.md")"
+      files="$(git diff --diff-filter=ACMRT --name-only --ignore-submodules=all "*.md")"
       ;;
     "branch")
-      files="$( (git diff --diff-filter=ACMRT --name-only "${BRANCH_NAME:-origin/main}" "*.md"; git diff --name-only "*.md") | sort | uniq )"
+      files="$( (git diff --diff-filter=ACMRT --name-only --ignore-submodules=all "${BRANCH_NAME:-origin/main}" "*.md"; git diff --name-only --ignore-submodules=all "*.md") | sort | uniq )"
       ;;
   esac
 

--- a/.github/actions/check-todo-usage/check-todos.sh
+++ b/.github/actions/check-todo-usage/check-todos.sh
@@ -65,13 +65,13 @@ function get_files_to_check() {
   local mode="$1"
   case "$mode" in
     staged-changes)
-      git diff --diff-filter=ACMRT --name-only --cached # ACMRT only show files added, copied, modified, renamed or that had their type changed (eg. file → symlink) in this commit. This leaves out deleted files.
+      git diff --diff-filter=ACMRT --name-only --cached --ignore-submodules=all # ACMRT only show files added, copied, modified, renamed or that had their type changed (eg. file → symlink) in this commit. This leaves out deleted files.
       ;;
     working-tree-changes)
-      git ls-files --others --exclude-standard && git diff --diff-filter=ACMRT --name-only
+      git ls-files --others --exclude-standard && git diff --diff-filter=ACMRT --name-only --ignore-submodules=all
       ;;
     branch)
-      git diff --diff-filter=ACMRT --name-only ${BRANCH_NAME:-origin/main}
+      git diff --diff-filter=ACMRT --name-only --ignore-submodules=all ${BRANCH_NAME:-origin/main}
       ;;
     all)
       git ls-files && git ls-files --others --exclude-standard


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

For pre-commit scripts, when gathering files which have changes in git, ignore the paths to any submodules.

## Context

In repositories that use git submodules, submodule pointer changes appear in diffs as directory paths. Pre-commit tools don't support this. E.g., editorconfig-checker (`check-file-format` hook) hangs and vale (`check-english-usage` hook) blows up with "stat: no such file or directory".

This change has no impact on repos without submodules.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
