### PR TITLE
CCM-18334: Firehose Delivery Stream Permissions Update

### DIFF
--- a/infrastructure/terraform/modules/eventpub/iam_role_sns.tf
+++ b/infrastructure/terraform/modules/eventpub/iam_role_sns.tf
@@ -49,4 +49,18 @@ data "aws_iam_policy_document" "firehose_delivery" {
       "${aws_kinesis_firehose_delivery_stream.main[0].arn}",
     ]
   }
+
+  statement {
+    sid    = "AllowKmsAccessForFirehoseDelivery"
+    effect = "Allow"
+
+    actions = [
+      "kms:GenerateDataKey",
+      "kms:Decrypt",
+    ]
+
+    resources = [
+      var.kms_key_arn,
+    ]
+  }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Added `kms:GenerateDataKey` and `kms:Decrypt` to the IAM policy for the SNS delivery role in [infrastructure/terraform/modules/eventpub/iam_role_sns.tf](infrastructure/terraform/modules/eventpub/iam_role_sns.tf#L53), so the principal that calls Firehose `PutRecord`/`PutRecordBatch` can write to the SSE-CMK-encrypted delivery stream.

## Context

AWS now requires callers of Firehose `PutRecord` and `PutRecordBatch` to have KMS data key and decrypt permissions when the delivery stream uses a customer-managed KMS key. Without this change, the shared eventpub module’s Firehose-backed delivery path would fail for encrypted streams.

<img width="522" height="489" alt="image" src="https://github.com/user-attachments/assets/da283e46-baaa-427b-b53b-d98d710c2e3e" />

Will require bumps of the version in the below:

- nhs-notify-digital-letters/infrastructure/terraform/components/dl/modules_eventpub.tf - **3.0.6**
- nhs-notify-supplier-api/infrastructure/terraform/components/api/modules_eventpub.tf - **3.0.6**
- nhs-notify-web-template-management/infrastructure/terraform/components/sbx/module_eventpub.tf - **3.0.6**
- nhs-notify-web-template-management/infrastructure/terraform/components/app/module_eventpub.tf - **3.0.6**
- comms-mgr/comms/terraform/components/api/module_eventpub.tf - **4.0.0**

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
